### PR TITLE
adds ended_at column to migration

### DIFF
--- a/book/rails/creating_a_get_request.md
+++ b/book/rails/creating_a_get_request.md
@@ -107,6 +107,7 @@ the migration was created):
           t.float :lon, null: false
           t.string :name, null: false
           t.datetime :started_at, null: false
+          t.datetime :ended_at
           t.integer :user_id, null: false
         end
 


### PR DESCRIPTION
ended_at is used in all specs and views so it should be listet in migration
