### PR TITLE
Corrected the file name for the event spec

### DIFF
--- a/book/rails/creating_a_get_request.md
+++ b/book/rails/creating_a_get_request.md
@@ -82,7 +82,7 @@ at a time to make them pass. We will use FactoryGirl, Shoulda Matchers, and
 RSpec for our unit tests. To see our full test setup, see our `spec_helper`
 [here](https://github.com/thoughtbot/ios-on-rails/blob/master/example_apps/rails/spec/spec_helper.rb).
 
-    # spec/models/event.rb
+    # spec/models/event_spec.rb
 
     require 'spec_helper'
 


### PR DESCRIPTION
I just found a quick typo. I don't remember what you use to generate the books so I couldn't change it in the releases. If it's some kind of open source tool, let me know and I'll try and export the releases too.
