### PR TITLE
Remove extra comma from routes file

### DIFF
--- a/book/rails/creating_a_post_request.md
+++ b/book/rails/creating_a_post_request.md
@@ -130,7 +130,7 @@ defined this route in our `routes.rb` file. Let's fix that:
     Humon::Application.routes.draw do
       scope module: :api, defaults: { format: 'json' } do
         namespace :v1 do
-          resources :events, only: [:create, :show,]
+          resources :events, only: [:create, :show]
         end
       end
     end


### PR DESCRIPTION
Super small extra comma in the routes file.

Fun fact: It actually doesn't cause an error which I was surprised at. Apparently ruby just ignores the extra comma at the end of an array. It won't ignore two though.
