### PR TITLE
Fix controller action in creating_a_geocoded_get_request.md

### DIFF
--- a/book/rails/creating_a_geocoded_get_request.md
+++ b/book/rails/creating_a_geocoded_get_request.md
@@ -272,7 +272,7 @@ correct message.
     # app/controllers/api/v1/events/nearests_controller.rb
 
     class Api::V1::Events::NearestsController < ApiController
-      def show
+      def index
 
       ...
 


### PR DESCRIPTION
Fixed action in chapter "Creating a geocoded GET request" from show to index according to my issue "Wrong controller action in geocoded get request chapter (#76)"
