### PR TITLE
fix humon-database-representation image path

### DIFF
--- a/book/rails/introduction.md
+++ b/book/rails/introduction.md
@@ -11,7 +11,7 @@ event has geolocation information (latitude and longitude), which allows us to
 plot it on a map. A user has and belongs to many events through attendances. A
 user can only have one attendance per event.
 
-![Humon database representation](images/humon-database-representation.png)
+![Humon database representation](../images/humon-database-representation.png)
 
 The Humon application does not ask for a username or password. Instead, we will
 use an ID unique to the device ('device token') to track unique users. The iOS


### PR DESCRIPTION
Path was pointing to book/rails/images. Needs to be book/images

before: 
![image](https://cloud.githubusercontent.com/assets/1279036/3621211/8b459338-0e10-11e4-953a-b74e62dc6afe.png)

after: 
![image](https://cloud.githubusercontent.com/assets/1279036/3621214/ae7c0fda-0e10-11e4-97f0-c030342f520d.png)
