### PR TITLE
Return user device token and id on POST user

### DIFF
--- a/example_apps/rails/app/controllers/api/v1/users_controller.rb
+++ b/example_apps/rails/app/controllers/api/v1/users_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::UsersController < ApiController
       @user = user
 
       if @user.save
-        render nothing: true
+        render
       else
         render json: {
           message: 'Validation Failed',

--- a/example_apps/rails/app/views/api/v1/users/create.json.jbuilder
+++ b/example_apps/rails/app/views/api/v1/users/create.json.jbuilder
@@ -1,0 +1,2 @@
+json.device_token @user.device_token
+json.id @user.id

--- a/example_apps/rails/spec/requests/api/v1/users_spec.rb
+++ b/example_apps/rails/spec/requests/api/v1/users_spec.rb
@@ -4,22 +4,29 @@ describe 'POST /v1/users' do
   it 'saves email, facebook id, first name, image_url, last name' do
     device_token = 'abc123'
 
-    post '/v1/users',
-      nil,
-      set_headers(device_token)
+    post '/v1/users', {}, set_headers(device_token)
 
     user = User.last
-    expect(user.device_token).to eq 'abc123'
+    expect(response_json).to eq(
+      {
+        'device_token' => user.device_token,
+        'id' => user.id
+       }
+    )
   end
 
   it 'does not create a user when a user aready exists with the device token' do
     device_token = 'abc123'
-    create(:user, device_token: device_token)
+    user = create(:user, device_token: device_token)
 
-    post '/v1/users',
-      nil,
-      set_headers(device_token)
+    post '/v1/users', {}, set_headers(device_token)
 
     expect(User.count).to eq 1
+    expect(response_json).to eq(
+      {
+        'device_token' => device_token,
+        'id' => user.id
+      }
+    )
   end
 end


### PR DESCRIPTION
- With changes in https://github.com/thoughtbot/ios-on-rails/pull/83, we
  are now sending the device token in the header and the user id in the
  body when we need to identify a user
- Because we are using both to identify users, the client needs to store
  both

https://trello.com/c/zOMtAeFk
