### PR TITLE
Update book text to discuss auth token in header

### DIFF
--- a/book/rails/creating_a_get_request.md
+++ b/book/rails/creating_a_get_request.md
@@ -52,7 +52,7 @@ which we use below and in all of our request specs that include a JSON response.
             'name' => event.name,
             'started_at' => event.started_at.as_json,
             'owner' => {
-              'device_token' => event.owner.device_token
+              'id' => event.owner.id
             }
           }
         )
@@ -212,7 +212,7 @@ the `events` directory. So we will create that partial next:
       json.started_at event.started_at
 
       json.owner do
-        json.device_token event.owner.device_token
+        json.id event.owner.id
       end
     end
 
@@ -264,7 +264,7 @@ your browser you should see something like this:
       "name":"Best event OF ALL TIME!",
       "started_at":"2013-09-16T00:00:00.000Z",
       "owner":{
-        "device_token":"234324235"
+        "id":"1"
        }
      }
 

--- a/book/rails/creating_a_patch_request.md
+++ b/book/rails/creating_a_patch_request.md
@@ -28,10 +28,11 @@ PATCH request.
           lon: event.lon,
           name: new_name,
           owner: {
-            device_token: event.owner.device_token
+            id: event.owner.id
           },
           started_at: event.started_at
-        }.to_json, { 'Content-Type' => 'application/json' }
+        }.to_json,
+        set_headers(event.owner.device_token)
 
         event.reload
         expect(event.name).to eq new_name
@@ -106,10 +107,13 @@ is to add logic to our `update` method that actually updates our `event`:
     # app/controllers/api/v1/events_controller.rb
 
     def update
-      @event = Event.find(params[:id])
+      authorize do |user|
+        @user = user
+        @event = Event.find(params[:id])
 
-      if @event.update_attributes(event_params)
-        render
+        if @event.update_attributes(event_params)
+          render
+        end
       end
     end
 
@@ -165,10 +169,11 @@ and to test drive that logic we will write a request spec:
            lon: event.lon,
            name: nil,
            owner: {
-             device_token: event.owner.device_token
+             id: event.owner.id
            },
            started_at: event.started_at
-         }.to_json, { 'Content-Type' => 'application/json' }
+         }.to_json,
+         set_headers(event.owner.device_token)
 
          event.reload
          expect(event.name).to_not be nil


### PR DESCRIPTION
- Add section about auth token in header
- use owner id instead of device token in json response
- Use `set_headers` helper method for specs
