### PR TITLE
Change the device token to an auth token in the iOS app

### DIFF
--- a/example_apps/iOS/Humon/Clients/HUMRailsAFNClient.m
+++ b/example_apps/iOS/Humon/Clients/HUMRailsAFNClient.m
@@ -26,15 +26,10 @@ static NSString *const HUMAFNAppSecret =
 
         if ([HUMUserSession userIsLoggedIn]) {
             [_sharedClient.requestSerializer setValue:[HUMUserSession userToken]
-                                   forHTTPHeaderField:@"tb-device-token"];
+                                   forHTTPHeaderField:@"tb-auth-token"];
         } else {
             [_sharedClient.requestSerializer setValue:HUMAFNAppSecret
                                    forHTTPHeaderField:@"tb-app-secret"];
-            // Currently the backend uses a device ID the client generates
-            // as our user token. Here we set that ID.
-            // We have plans to change the backend to generate user tokens for us.
-            [_sharedClient.requestSerializer setValue:[[NSUUID UUID] UUIDString]
-                                   forHTTPHeaderField:@"tb-device-token"];
         }
         
     });
@@ -49,9 +44,9 @@ static NSString *const HUMAFNAppSecret =
        success:^(NSURLSessionDataTask *task, id responseObject) {
            
         [HUMUserSession setUserID:responseObject[@"id"]];
-        [HUMUserSession setUserToken:responseObject[@"device_token"]];
-        [self.requestSerializer setValue:responseObject[@"device_token"]
-                         forHTTPHeaderField:@"tb-device-token"];
+        [HUMUserSession setUserToken:responseObject[@"auth_token"]];
+        [self.requestSerializer setValue:responseObject[@"auth_token"]
+                         forHTTPHeaderField:@"tb-auth-token"];
         block(nil);
            
        } failure:^(NSURLSessionDataTask *task, NSError *error) {

--- a/example_apps/iOS/Humon/Clients/HUMRailsClient.m
+++ b/example_apps/iOS/Humon/Clients/HUMRailsClient.m
@@ -47,19 +47,15 @@ static NSString *const HUMAppSecret =
     sessionConfiguration.timeoutIntervalForRequest = 30.0;
     sessionConfiguration.timeoutIntervalForResource = 30.0;
 
-    // Currently the backend uses a device ID the client generates
-    // as our user token. Here we set that ID.
-    // We have plans to change the backend to generate user tokens for us.
     NSDictionary *headers = [HUMUserSession userIsLoggedIn] ?
         @{
           @"Accept" : @"application/json",
           @"Content-Type" : @"application/json",
-          @"tb-device-token" : [HUMUserSession userToken]
+          @"tb-auth-token" : [HUMUserSession userToken]
           } :
         @{
           @"Accept" : @"application/json",
           @"Content-Type" : @"application/json",
-          @"tb-device-token" : [[NSUUID UUID] UUIDString],
           @"tb-app-secret" : HUMAppSecret
           };
     [sessionConfiguration setHTTPAdditionalHeaders:headers];
@@ -86,7 +82,7 @@ static NSString *const HUMAppSecret =
                                                 JSONObjectWithData:data
                                                 options:kNilOptions
                                                 error:nil];
-            [HUMUserSession setUserToken:responseDictionary[@"device_token"]];
+            [HUMUserSession setUserToken:responseDictionary[@"auth_token"]];
             [HUMUserSession setUserID:responseDictionary[@"id"]];
 
             NSURLSessionConfiguration *newConfiguration =
@@ -95,7 +91,7 @@ static NSString *const HUMAppSecret =
                 @{
                     @"Accept" : @"application/json",
                     @"Content-Type" : @"application/json",
-                    @"tb-device-token" : responseDictionary[@"device_token"]
+                    @"tb-auth-token" : responseDictionary[@"auth_token"]
                 }];
             
             [self.session finishTasksAndInvalidate];


### PR DESCRIPTION
The backend now generates user tokens for us. So, this is an update to the iOS app to handle that change. We do not need to create these on the client anymore. This is a Super Good Thing.
