### PR TITLE
Add bin/setup and bin/deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /build/
-bin
 .env

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Run this script to deploy the app to Heroku.
+
+set -e
+
+target="${1:-staging}"
+
+git subtree push --prefix=example_apps/rails "$target" "master"
+heroku run rake db:migrate --remote "$target"
+heroku restart --remote "$target"

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+
+# Set up the staging and production apps.
+if heroku join --app humon-staging &> /dev/null; then
+  git remote add staging git@heroku.com:humon-staging.git || true
+  printf 'You are a collaborator on the "humon-staging" Heroku app
+'
+else
+  printf 'Ask for access to the "humon-staging" Heroku app
+'
+fi
+
+if heroku join --app humon-production &> /dev/null; then
+  git remote add production git@heroku.com:humon-production.git || true
+  printf 'You are a collaborator on the "humon-production" Heroku app
+'
+else
+  printf 'Ask for access to the "humon-production" Heroku app
+'
+fi


### PR DESCRIPTION
The Rails application is deployed on Heroku from the app in
`example_apps/rails`. It was previously deployed from a separate
`humon-rails` repository, but that was before the app was imported
directly into the book repo.

This adds `bin/setup` and `bin/deploy` scripts based on those generated
by suspenders for deploying the Rails application from this repository.
